### PR TITLE
Sync versions with Windup core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- ~ Copyright 2012 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under the Eclipse Public License version 1.0, available 
+<!-- ~ Copyright 2012 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under the Eclipse Public License version 1.0, available
     at ~ http://www.eclipse.org/legal/epl-v10.html -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -22,7 +22,8 @@
     <properties>
         <version.nexus.index>3</version.nexus.index>
         <version.windup>2.3.0.Final</version.windup>
-        <version.forge>2.15.2.Final</version.forge>
+        <version.forge>2.16.2.Final</version.forge>
+        <version.furnace>2.18.2.Final</version.furnace>
 
         <windup.scm.connection>scm:git:https://github.com/windup/windup-distribution.git</windup.scm.connection>
         <windup.developer.connection>scm:git:git@github.com:windup/windup-distribution.git</windup.developer.connection>
@@ -59,6 +60,7 @@
             <plugin>
                 <groupId>org.jboss.forge.furnace</groupId>
                 <artifactId>furnace-maven-plugin</artifactId>
+                <version>${version.furnace}</version>
                 <executions>
                     <execution>
                         <id>deploy-addons</id>
@@ -87,6 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.5</version>
                 <executions>
                     <execution>
                         <id>distribution-offline</id>
@@ -143,7 +146,7 @@
     </profiles>
 
     <scm>
-        <tag>2.2.0.Final</tag>
+        <tag>${version.windup}</tag>
         <connection>${windup.scm.connection}</connection>
         <developerConnection>${windup.developer.connection}</developerConnection>
         <url>${windup.scm.url}</url>


### PR DESCRIPTION
Currently the build fails on the dot plugin.

(19:02:05) jsightler: Yeah, I'm really confused as to why this works here, though
(19:02:12) jsightler: ozizka: Which maven version are you on?
(19:02:25) ozizka-FN: jsightler: Behaves the same with 3.3.3 and 3.2.5
(19:02:33) ozizka-FN: I.e. 
(19:02:38) jsightler: Hmm, I'm on 3.2.5
(19:02:39) ozizka-FN: not working with older furnace
(19:02:47) ozizka-FN: the new works with both mavens
(19:03:24) ozizka-FN: From what I understand, the distribution is using old version of furnace when creating the package?
(19:03:31) ozizka-FN: Without the PR
(19:03:42) jsightler: I guess that is possible.
(19:03:44) ozizka-FN: I am not sure what's the role of that forge plugin
(19:03:52) jsightler: Do you mind making the furnace version a property in this PR?
(19:04:00) ozizka-FN: So maybe the 2.3.0 is released with the older furnace?
(19:04:50) ozizka-FN: jsightler: For the furnace-maven-plugin ?
(19:04:51) ozizka-FN: Ok
(19:04:55) jsightler: ozizka: Yeah, it appears to be a mix. Mostly 2.16.2, but a couple of older ones.
(19:05:07) jsightler: ozizka: Right. I'm hoping that makes it harder to miss. :)
(19:05:15) jsightler: (since we seem to forget to update this)
(19:05:53) ozizka-FN: I meant forge obviously - for those
(19:05:53) ozizka-FN:                                 <addonId>org.jboss.forge.addon:addon-manager,${version.forge}</addonId>
(19:06:15) jsightler: yes
(19:06:26) ozizka-FN: jsightler:  I was thinking if we could make it taken from windup core somehow
(19:06:37) ozizka-FN: Maven doesn't allow to distribute versions from pom, right?
(19:06:41) jsightler: ozizka: That would be ideal, but I haven't seen a way to do that.
(19:06:42) ozizka-FN: I mean,
(19:06:43) ozizka-FN: properties
(19:06:50) jsightler: properties aren't pulled in from a bom
(19:07:28) ozizka-FN: Hmm hm so only .properties, and that could be loaded by maven-properties-plugin, but this properties fiddling fails a lot,
(19:07:38) ozizka-FN: there are few stages at which maven processes them
(19:07:48) ozizka-FN: and various plugins get or do not get the right value
(19:07:57) ozizka-FN: s/right//g
(19:08:07) jsightler: right
(19:08:35) ozizka-FN: jsightler:  And how about this
(19:08:37) ozizka-FN:     <scm>
(19:08:37) ozizka-FN:         <tag>2.2.0.Final</tag>
(19:08:59) ozizka-FN: I guess that should also be 2.3.0 now
(19:09:20) ozizka-FN: Or not be there at all
(19:09:28) ozizka-FN: Only for the tagged source state
(19:10:09) ozizka-FN: But since we only release artifacts on tags, then:
(19:10:10) ozizka-FN:     <scm>
(19:10:10) ozizka-FN:         <tag>${version.windup}</tag>
(19:10:10) ozizka-FN: ?
(19:11:00) jsightler: Yeah, I think that would work?