### PR TITLE
Fix absolute paths

### DIFF
--- a/src/main/assembly/assembly-offline.xml
+++ b/src/main/assembly/assembly-offline.xml
@@ -11,14 +11,14 @@
    <fileSets>
       <fileSet>
          <directory>src/main/resources</directory>
-         <outputDirectory>/</outputDirectory>
+         <outputDirectory></outputDirectory>
          <includes>
             <include>**</include>
          </includes>
       </fileSet>
       <fileSet>
          <directory>${project.build.directory}/addons</directory>
-         <outputDirectory>/addons</outputDirectory>
+         <outputDirectory>addons</outputDirectory>
          <includes>
             <include>**</include>
          </includes>


### PR DESCRIPTION
[INFO] --- maven-assembly-plugin:2.5.5:single (distribution-offline) @ windup-distribution ---
[INFO] Reading assembly descriptor: src/main/assembly/assembly-offline.xml
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /addons