### PR TITLE
Replaced windup version by a reference to ${project.version}

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <version.nexus.index>4</version.nexus.index>
-        <version.windup>2.4.0.CR1</version.windup>
+        <version.windup>${project.version}</version.windup>
         <version.forge>2.16.2.Final</version.forge>
         <version.furnace>2.18.2.Final</version.furnace>
 


### PR DESCRIPTION
I just spent half an hour to try to understand why my updated rules where not shipped with the offline distribution till I came on this.
I think it is a good idea to commit this change replacing a fix-coded windup version number with a reference to ${project.version}. This makes sure that the right version number is used.

