### PR TITLE
Link to official docs rather than wiki for user guide

### DIFF
--- a/src/main/resources/README.txt
+++ b/src/main/resources/README.txt
@@ -48,7 +48,7 @@ Run Windup
         
 Get more resources
 ---------------------
-    User Guide is available at https://github.com/windup/windup/wiki/User-Guide
+    User Guide is available at https://access.redhat.com/documentation/en/red-hat-jboss-migration-toolkit
     Windup Wiki - https://github.com/windup/windup/wiki 
     Windup Forum for users - https://community.jboss.org/en/windup
     Windup JIRA issue trackers


### PR DESCRIPTION
Using the URL that points to the docs splash page since it keeps itself up to date with the latest version.