### PR TITLE
Increase H2 console timeout to 48 hours

### DIFF
--- a/src/main/resources/bin/rhamt-cli
+++ b/src/main/resources/bin/rhamt-cli
@@ -224,5 +224,5 @@ exec $JAVACMD "${RHAMT_DEBUG_ARGS[@]}" \
     -Dforge.standalone=true \
     -Dforge.home=${RHAMT_HOME} \
     -Dwindup.home=${RHAMT_HOME} \
-    -Dh2.consoleTimeout=24000000 \
+    -Dh2.consoleTimeout=172800000 \
     -cp ${RHAMT_HOME}/lib/'*' $RHAMT_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"

--- a/src/main/resources/bin/rhamt-cli
+++ b/src/main/resources/bin/rhamt-cli
@@ -219,5 +219,10 @@ fi
 
 RHAMT_OPTS="$RHAMT_OPTS $FILE_DESCRIPTOR_OPTS";
 
-exec $JAVACMD "${RHAMT_DEBUG_ARGS[@]}" $RHAMT_OPTS -Dforge.standalone=true -Dforge.home=${RHAMT_HOME} -Dwindup.home=${RHAMT_HOME} \
-   -cp ${RHAMT_HOME}/lib/'*' $RHAMT_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"
+exec $JAVACMD "${RHAMT_DEBUG_ARGS[@]}" \
+    $RHAMT_OPTS \
+    -Dforge.standalone=true \
+    -Dforge.home=${RHAMT_HOME} \
+    -Dwindup.home=${RHAMT_HOME} \
+    -Dh2.consoleTimeout=24000000 \
+    -cp ${RHAMT_HOME}/lib/'*' $RHAMT_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"


### PR DESCRIPTION
For debug purposes. Doesn't change anything for the user.

https://www.h2database.com/javadoc/org/h2/engine/SysProperties.html#h2.socketConnectTimeout