### PR TITLE
Fix spaces in rhamt path (#50)

### DIFF
--- a/src/main/resources/bin/rhamt-cli
+++ b/src/main/resources/bin/rhamt-cli
@@ -243,5 +243,5 @@ fi
 
 RHAMT_OPTS="$RHAMT_OPTS $FILE_DESCRIPTOR_OPTS";
 
-exec $JAVACMD "${RHAMT_DEBUG_ARGS[@]}" $RHAMT_OPTS -Dforge.standalone=true -Dforge.home=${RHAMT_HOME} -Dwindup.home=${RHAMT_HOME} \
-   -cp ${RHAMT_HOME}/lib/'*' $RHAMT_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"
+exec "$JAVACMD" "${RHAMT_DEBUG_ARGS[@]}" $RHAMT_OPTS -Dforge.standalone=true -Dforge.home="${RHAMT_HOME}" -Dwindup.home="${RHAMT_HOME}" \
+   -cp "${RHAMT_HOME}"/lib/'*' $RHAMT_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"


### PR DESCRIPTION
* Fix cli launcher when JAVA_HOME have space

* Also fix the case where rhamt is installed in a directory with a space