### PR TITLE
prepare for next release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.windup>4.1.0-SNAPSHOT</version.windup>
+        <version.windup>4.0.1-SNAPSHOT</version.windup>
         <version.forge>3.6.0.Final</version.forge>
         <version.furnace>2.25.4.Final</version.furnace>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>org.jboss.windup</groupId>
     <artifactId>rhamt-cli</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
 
     <name>RHAMT - Distribution Build</name>
     <packaging>pom</packaging>


### PR DESCRIPTION
Changed artifact version from `4.1.0-SNAPSHOT` to `4.0.1-SNAPSHOT`.
Done using `mvn --batch-mode release:update-versions -DdevelopmentVersion=4.0.1-SNAPSHOT` command from the [maven-release-plugin](http://maven.apache.org/maven-release/maven-release-plugin/examples/update-versions.html#)
The `release-pom.xml` file was already deleted in https://github.com/windup/windup-distribution/commit/23657dc4ac70f7567365070c1d8ac6772ca14459