### PR TITLE
WINDUP-2149: bump furnace version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
 
     <properties>
         <version.windup>4.2.0-SNAPSHOT</version.windup>
-        <version.forge>3.7.2.Final</version.forge>
-        <version.furnace>2.26.2.Final</version.furnace>
+        <version.forge>3.9.0.Final</version.forge>
+        <version.furnace>2.28.2.Final</version.furnace>
 
         <windup.scm.connection>scm:git:https://github.com/windup/windup-distribution.git</windup.scm.connection>
         <windup.developer.connection>scm:git:git@github.com:windup/windup-distribution.git</windup.developer.connection>


### PR DESCRIPTION
as long as https://issues.jboss.org/browse/MODULES-372 is not fixed, there is still a piece in the rhamt-cli scripts missing which appends the java.se module if the java version is >= 9