### PR TITLE
WINDUP-2273 Update README to reference windup-local-build-scripts

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -9,6 +9,8 @@ This projects contains dependencies on the following projects, which must be bui
 * https://github.com/windup/windup-rulesets[windup-rulesets]: This project contains the RHAMT rules.
 * https://github.com/windup/windup[windup]: This project contains the Windup core source code.
 
+A script to build this project and its dependencies (above) can be found here: https://github.com/windup/windup-local-build-scripts[windup-local-build-scripts].
+
 More detailed instructions are located here: https://github.com/windup/windup/wiki/Dev-Build-from-Source[Build Windup from Source].
 
 == Build the Project


### PR DESCRIPTION
Added a link to the windup-local-build-scripts github repository to make it easy to build the windup-distribution project and its dependencies.