### PR TITLE
WINDUP-3128-openrewrite-cli: assemble rewrite.yml to enable openrewri…

### DIFF
--- a/src/main/assembly/assembly-offline.xml
+++ b/src/main/assembly/assembly-offline.xml
@@ -51,6 +51,16 @@
             <includes>
                 <include>**</include>
             </includes>
+            <excludes>
+                <exclude>*/rewrite.yml</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/rules/openrewrite</directory>
+            <outputDirectory>rules/openrewrite</outputDirectory>
+            <includes>
+                <include>rewrite.yml</include>
+            </includes>
         </fileSet>
     </fileSets>
 


### PR DESCRIPTION
…te run from cli

this needs this rulesets PR to work: https://github.com/windup/windup-rulesets/pull/570

Once built and extracted, 
run in your terminal shell: `export MTA_HOME=/home/mbrophy/BuiltApps/mta-cli-5.2.1-SNAPSHOT`
or whatever the path is to where you've extracted your files
then run in the root of the project you wish to transform `mvn org.openrewrite.maven:rewrite-maven-plugin:4.14.1:run -Drewrite.configLocation=${MTA_HOME}/rules/openrewrite/rewrite.yml -DactiveRecipes=org.jboss.windup.JavaxToJakarta`
