### PR TITLE
WINDUP-3128: mta-cli script openrewrite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.windup>5.2.0.Final</version.windup>
+        <version.windup>5.2.1-SNAPSHOT</version.windup>
         <version.forge>3.9.2.Final</version.forge>
         <version.furnace>2.28.4.Final</version.furnace>
 

--- a/src/main/assembly/assembly-no-index.xml
+++ b/src/main/assembly/assembly-no-index.xml
@@ -51,6 +51,16 @@
             <includes>
                 <include>**</include>
             </includes>
+            <excludes>
+                <exclude>*/rewrite.yml</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/rules/openrewrite</directory>
+            <outputDirectory>rules/openrewrite</outputDirectory>
+            <includes>
+                <include>rewrite.yml</include>
+            </includes>
         </fileSet>
     </fileSets>
 

--- a/src/main/resources/bin/mta-cli
+++ b/src/main/resources/bin/mta-cli
@@ -272,7 +272,7 @@ fi
 MTA_OPTS="$MTA_OPTS $FILE_DESCRIPTOR_OPTS";
 
 if [ "$RUN_OPENREWRITE" != "" ] ; then
-	( cd "$TRANSFORM_PROJECT_PATH"; exec mvn org.openrewrite.maven:rewrite-maven-plugin:4.13.0:"${OPENREWRITE_GOAL}" -Drewrite.configLocation="${MTA_HOME}"/rules/openrewrite/rewrite.yml "${OPENREWRITE_QUOTED_ARGS[@]}" )
+	( cd "$TRANSFORM_PROJECT_PATH"; exec mvn org.openrewrite.maven:rewrite-maven-plugin:4.13.0:"${OPENREWRITE_GOAL}" -DconfigLocation="${MTA_HOME}"/rules/openrewrite/rewrite.yml "${OPENREWRITE_QUOTED_ARGS[@]}" )
 	exit 0;
 
 fi

--- a/src/main/resources/bin/mta-cli
+++ b/src/main/resources/bin/mta-cli
@@ -272,7 +272,7 @@ fi
 MTA_OPTS="$MTA_OPTS $FILE_DESCRIPTOR_OPTS";
 
 if [ "$RUN_OPENREWRITE" != "" ] ; then
-	( cd "$TRANSFORM_PROJECT_PATH"; exec mvn org.openrewrite.maven:rewrite-maven-plugin:4.14.1:"${OPENREWRITE_GOAL}" -Drewrite.configLocation="${MTA_HOME}"/rules/openrewrite/rewrite.yml "${OPENREWRITE_QUOTED_ARGS[@]}" )
+	( cd "$TRANSFORM_PROJECT_PATH"; exec mvn org.openrewrite.maven:rewrite-maven-plugin:4.13.0:"${OPENREWRITE_GOAL}" -Drewrite.configLocation="${MTA_HOME}"/rules/openrewrite/rewrite.yml "${OPENREWRITE_QUOTED_ARGS[@]}" )
 	exit 0;
 
 fi

--- a/src/main/resources/bin/mta-cli
+++ b/src/main/resources/bin/mta-cli
@@ -27,6 +27,10 @@
 ADDONS_DIR=()
 MTA_DEBUG_ARGS=()
 QUOTED_ARGS=()
+RUN_OPENREWRITE=()
+TRANSFORM_PROJECT_PATH=()
+OPENREWRITE_QUOTED_ARGS=()
+OPENREWRITE_GOAL=( "dryRun" )
 
 ## Increase the open file limit if low, to what we need or at least to the hard limit.
 ## Complain if the hard limit is lower than what we need.
@@ -84,8 +88,23 @@ while [ "$1" != "" ] ; do
   if [ "$1" = "--debug" ] ; then
     MTA_DEBUG_ARGS=( "-Xdebug" "-Xnoagent" "-Djava.compiler=NONE" "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000" )
   fi
-
+  
+  if [ "$1" = "--openrewrite" ] ; then
+    RUN_OPENREWRITE=( "yes" ) 
+  elif [ "$1" = "--input" ] ; then
+    TRANSFORM_PROJECT_PATH=("$2")
+  elif [ "$1" = "$TRANSFORM_PROJECT_PATH" ] ; then
+  	pathfound=true
+  elif [ "$1" = "--goal" ] ; then
+    OPENREWRITE_GOAL=("$2")
+  elif [ "$1" = "$OPENREWRITE_GOAL" ] ; then
+  	goalfound=true
+  else
+  	OPENREWRITE_QUOTED_ARGS+=("$1")
+  fi 
+  
   QUOTED_ARGS+=("$1")
+  
   shift
 done
 
@@ -251,6 +270,12 @@ if [ -z "$MTA_OPTS" ] ; then
 fi
 
 MTA_OPTS="$MTA_OPTS $FILE_DESCRIPTOR_OPTS";
+
+if [ "$RUN_OPENREWRITE" != "" ] ; then
+	( cd "$TRANSFORM_PROJECT_PATH"; exec mvn org.openrewrite.maven:rewrite-maven-plugin:4.14.1:"${OPENREWRITE_GOAL}" -Drewrite.configLocation="${MTA_HOME}"/rules/openrewrite/rewrite.yml "${OPENREWRITE_QUOTED_ARGS[@]}" )
+	exit 0;
+
+fi
 
 exec "$JAVACMD" $MODULES "${MTA_DEBUG_ARGS[@]}" $MTA_OPTS -Dforge.standalone=true -Dforge.home="${MTA_HOME}" -Dwindup.home="${MTA_HOME}" \
    -cp "${MTA_HOME}"/lib/'*' $MTA_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"

--- a/src/main/resources/bin/mta-cli.bat
+++ b/src/main/resources/bin/mta-cli.bat
@@ -215,7 +215,7 @@ if %RUN_OPENREWRITE%==false goto runMTA_CLI
 
 :runOpenrewrite
 PUSHD "%OR_TRANSFORM_PATH%"
-mvn "org.openrewrite.maven:rewrite-maven-plugin:4.13.0:%OR_GOAL%" "-Drewrite.configLocation=%MTA_HOME%\rules\openrewrite\rewrite.yml" %OR_CMD_LINE_ARGS%
+mvn "org.openrewrite.maven:rewrite-maven-plugin:4.13.0:%OR_GOAL%" "-DconfigLocation=%MTA_HOME%\rules\openrewrite\rewrite.yml" %OR_CMD_LINE_ARGS%
 POPD
 
 if ERRORLEVEL 1 goto error


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3128

this needs this rulesets PR to work: windup/windup-rulesets#570

an openrewrite migration can now be called from the mta-cli script using this format of command:

`./mta-cli --openrewrite "-DactiveRecipes=org.jboss.windup.JavaxToJakarta" --input /home/mbrophy/Projects/spring-petclinic-migration --goal dryRun`

Argument details:

`--openrewrite` this is a flag specifying to run an openrewrite migration rather than an MTA analysis. The two cannot be run together simultaneously, it must be one or the other.

`"-DactiveRecipes=org.jboss.windup.JavaxToJakarta"` This tells openrewrite which recipe to apply to the input project. JavaxtoJakarta is the default shipped recipe but a user can add their own to the shipped rewrite.yml and run that recipe instead if they so choose. The shipped rewrite.yml file is located in the `rules/openrewrite/` folder in the unzipped MTA distribution.

`--input` this is the path to the source project which the openrewrite migration is to be performed upon.

`--goal` this is the openrewrite maven goal to run. This argument is optional, if not supplied the script will run the `dryRun`goal which reports on the changes and creates a patch file which can be applied later. To apply the recipe changes immediately without this stage, the `run` goal can be supplied as this argument instead.
