### PR TITLE
WINDUP-3210: MTA Openrewrite - extensibility

### DIFF
--- a/src/main/assembly/assembly-no-index.xml
+++ b/src/main/assembly/assembly-no-index.xml
@@ -59,7 +59,7 @@
             <directory>${project.build.directory}/rules/openrewrite</directory>
             <outputDirectory>rules/openrewrite</outputDirectory>
             <includes>
-                <include>rewrite.yml</include>
+                <include>**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/src/main/assembly/assembly-offline.xml
+++ b/src/main/assembly/assembly-offline.xml
@@ -59,7 +59,7 @@
             <directory>${project.build.directory}/rules/openrewrite</directory>
             <outputDirectory>rules/openrewrite</outputDirectory>
             <includes>
-                <include>rewrite.yml</include>
+                <include>**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/src/main/assembly/assembly-offline.xml
+++ b/src/main/assembly/assembly-offline.xml
@@ -52,7 +52,7 @@
                 <include>**</include>
             </includes>
             <excludes>
-                <exclude>*/rewrite.yml</exclude>
+                <exclude>openrewrite/</exclude>
             </excludes>
         </fileSet>
         <fileSet>

--- a/src/main/resources/bin/mta-cli
+++ b/src/main/resources/bin/mta-cli
@@ -272,7 +272,7 @@ fi
 MTA_OPTS="$MTA_OPTS $FILE_DESCRIPTOR_OPTS";
 
 if [ "$RUN_OPENREWRITE" != "" ] ; then
-	( cd "$TRANSFORM_PROJECT_PATH"; exec mvn org.openrewrite.maven:rewrite-maven-plugin:4.13.0:"${OPENREWRITE_GOAL}" -DconfigLocation="${MTA_HOME}"/rules/openrewrite/rewrite.yml "${OPENREWRITE_QUOTED_ARGS[@]}" )
+	( cd "$TRANSFORM_PROJECT_PATH"; exec mvn org.openrewrite.maven:rewrite-maven-plugin:4.13.0:"${OPENREWRITE_GOAL}" "${OPENREWRITE_QUOTED_ARGS[@]}" )
 	exit 0;
 
 fi

--- a/src/main/resources/bin/mta-cli.bat
+++ b/src/main/resources/bin/mta-cli.bat
@@ -215,7 +215,7 @@ if %RUN_OPENREWRITE%==false goto runMTA_CLI
 
 :runOpenrewrite
 PUSHD "%OR_TRANSFORM_PATH%"
-mvn "org.openrewrite.maven:rewrite-maven-plugin:4.13.0:%OR_GOAL%" "-DconfigLocation=%MTA_HOME%\rules\openrewrite\rewrite.yml" %OR_CMD_LINE_ARGS%
+mvn "org.openrewrite.maven:rewrite-maven-plugin:4.13.0:%OR_GOAL%"  %OR_CMD_LINE_ARGS%
 POPD
 
 if ERRORLEVEL 1 goto error


### PR DESCRIPTION
openrewrite file structure amended to allow any file in openrewrite directory to be included in built distribution

you need to include -DconfigLocation=<path-to-rewrite-yaml-file> in your command when calling from mta-cli 