### PR TITLE
Enhance maven-assembly-plugin config to allow maven commands from outside the root folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
                             </goals>
                             <configuration>
                                 <descriptors>
-                                    <descriptor>src/main/assembly/assembly-offline.xml</descriptor>
+                                    <descriptor>${multi.module.project.basedir}/src/main/assembly/assembly-offline.xml</descriptor>
                                 </descriptors>
                             </configuration>
                         </execution>
@@ -198,7 +198,7 @@
                             </goals>
                             <configuration>
                                 <descriptors>
-                                    <descriptor>src/main/assembly/assembly-no-index.xml</descriptor>
+                                    <descriptor>${multi.module.project.basedir}/src/main/assembly/assembly-no-index.xml</descriptor>
                                 </descriptors>
                             </configuration>
                         </execution>
@@ -207,6 +207,24 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <id>directories</id>
+                        <goals>
+                            <goal>highest-basedir</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <property>multi.module.project.basedir</property>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <!-- This declaration makes sure children get plugin in their lifecycle -->
                 <groupId>org.jboss.forge.furnace</groupId>


### PR DESCRIPTION
## How to reproduce the error in MASTER branch
Locate your terminal outside this repository and execute the `install` maven command pointing to this repository. E.g.

```
mvn clean install -DskipTests -f windup-distribution/
````

The command should fail.

## Solution in this PR

Checkout this PR and execute the same command from previous section.

```
mvn clean install -DskipTests -f windup-distribution/
```

The command should work now