### PR TITLE
Refactored themes management

### DIFF
--- a/mta-cli/pom.xml
+++ b/mta-cli/pom.xml
@@ -10,6 +10,34 @@
     </parent>
 
     <artifactId>mta-cli</artifactId>
-    <name>MTA - Distribution Build</name>
+    <name>Windup - Distribution Build MTA</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.windup</groupId>
+            <artifactId>windup-bootstrap-mta</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jboss.windup.rules</groupId>
+                                    <artifactId>windup-rulesets-mta</artifactId>
+                                    <version>${version.windup-rulesets}</version>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/mtr-cli/pom.xml
+++ b/mtr-cli/pom.xml
@@ -10,6 +10,34 @@
     </parent>
 
     <artifactId>mtr-cli</artifactId>
-    <name>MTR - Distribution Build</name>
+    <name>Windup - Distribution Build MTR</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.windup</groupId>
+            <artifactId>windup-bootstrap-mtr</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jboss.windup.rules</groupId>
+                                    <artifactId>windup-rulesets-mtr</artifactId>
+                                    <version>${version.windup-rulesets}</version>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -53,17 +53,13 @@
            </dependency>
            <dependency>
                 <groupId>org.jboss.windup.rules</groupId>
-                <artifactId>windup-rulesets</artifactId>
+                <artifactId>windup-rulesets-parent</artifactId>
                 <version>${version.windup-rulesets}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.windup</groupId>
-            <artifactId>windup-bootstrap</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.jboss.windup.maven</groupId>
             <artifactId>nexus-indexer-data</artifactId>
@@ -74,11 +70,6 @@
                     <artifactId>nexus-indexer</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.windup.rules</groupId>
-            <artifactId>windup-rulesets</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -131,14 +122,7 @@
                                 <goal>unpack</goal>
                             </goals>
                             <configuration>
-                                <artifactItems>
-                                    <artifactItem>
-                                        <groupId>org.jboss.windup.rules</groupId>
-                                        <artifactId>windup-rulesets</artifactId>
-                                        <overWrite>true</overWrite>
-                                        <outputDirectory>${project.build.directory}/rules</outputDirectory>
-                                    </artifactItem>
-                                </artifactItems>
+                                <outputDirectory>${project.build.directory}/rules</outputDirectory>
                                 <excludes>**/tests/**</excludes>
                             </configuration>
                         </execution>
@@ -382,7 +366,7 @@
             <id>windup</id>
             <activation>
                 <property>
-                    <name>!downstream</name>
+                    <name>!skipThemeWindup</name>
                 </property>
             </activation>
             <properties>
@@ -397,12 +381,6 @@
         </profile>
         <profile>
             <id>mta</id>
-            <activation>
-                <property>
-                    <name>downstream</name>
-                    <value>mta</value>
-                </property>
-            </activation>
             <properties>
                 <product-name>mta</product-name>
             </properties>
@@ -415,12 +393,6 @@
         </profile>
         <profile>
             <id>tackle</id>
-            <activation>
-                <property>
-                    <name>downstream</name>
-                    <value>tackle</value>
-                </property>
-            </activation>
             <properties>
                 <product-name>tackle</product-name>
             </properties>
@@ -433,12 +405,6 @@
         </profile>
         <profile>
             <id>mtr</id>
-            <activation>
-                <property>
-                    <name>downstream</name>
-                    <value>mtr</value>
-                </property>
-            </activation>
             <properties>
                 <product-name>mtr</product-name>
             </properties>

--- a/tackle-cli/pom.xml
+++ b/tackle-cli/pom.xml
@@ -10,6 +10,34 @@
     </parent>
 
     <artifactId>tackle-cli</artifactId>
-    <name>Tackle - Distribution Build</name>
+    <name>Windup - Distribution Build Tackle</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.windup</groupId>
+            <artifactId>windup-bootstrap-tackle</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jboss.windup.rules</groupId>
+                                    <artifactId>windup-rulesets-tackle</artifactId>
+                                    <version>${version.windup-rulesets}</version>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/windup-cli/pom.xml
+++ b/windup-cli/pom.xml
@@ -10,6 +10,34 @@
     </parent>
 
     <artifactId>windup-cli</artifactId>
-    <name>Windup - Distribution Build</name>
+    <name>Windup - Distribution Build Windup</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.windup</groupId>
+            <artifactId>windup-bootstrap-windup</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jboss.windup.rules</groupId>
+                                    <artifactId>windup-rulesets-windup</artifactId>
+                                    <version>${version.windup-rulesets}</version>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
depends on https://github.com/windup/windup/pull/1515 and https://github.com/windup/windup-rulesets/pull/740

- `windup` theme enabled by default. To disable it run with option `-DskipThemeWindup`
- other themes can be built using profiles (i.e. `-P<theme_name>`)
- do **NOT** build more than one CLI per build