### PR TITLE
Fix maven 3.9.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,13 @@
                     <groupId>org.jboss.forge.furnace</groupId>
                     <artifactId>furnace-maven-plugin</artifactId>
                     <version>${version.furnace}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-utils</artifactId>
+                            <version>3.5.0</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>deploy-addons</id>
@@ -215,7 +222,7 @@
                 <groupId>org.jboss.forge.furnace</groupId>
                 <artifactId>furnace-maven-plugin</artifactId>
                 <!-- Configuration won't be propagated to children -->
-                <inherited>false</inherited>
+                <inherited>true</inherited>
                 <executions>
                     <execution>
                         <!--This matches and thus overrides execution defined above -->


### PR DESCRIPTION
Latest version of Maven 3.9.0 is by default installed in Windows and MacOS. Linux still uses Maven 3.8.7 but soon it should change.

Maven 3.9.0 removed the injection of `plexus-utils`. Maven plugins that depend of that dependency must be upgraded (maintainers of each maven plugin). In our case (users of a maven plugin affected by this change) we can set manually the problematic dependency until the maintainer of the plugin makes changes on it. Read more at https://maven.apache.org/docs/3.9.0/release-notes.html#potentially-breaking-core-changes