### PR TITLE
Fix: configure furnace-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
                 <groupId>org.jboss.forge.furnace</groupId>
                 <artifactId>furnace-maven-plugin</artifactId>
                 <!-- Configuration won't be propagated to children -->
-                <inherited>true</inherited>
+                <inherited>false</inherited>
                 <executions>
                     <execution>
                         <!--This matches and thus overrides execution defined above -->


### PR DESCRIPTION
Current master branch present issues. The final CLI does not include certain parameter like `--input`. The issue appeared after merging https://github.com/windup/windup-distribution/pull/104

This PR should revert one line change to make the CLI work again. However, it means the repository won't be Maven 3.9.0 compatible. Only version less than 3.8.7 of maven will work until further PRs come to achieve Maven 3.9.0 compatibility