### PR TITLE
Fix Maven version to '3.8.7'

### DIFF
--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -81,5 +81,9 @@ jobs:
         key: maven-windup-cli-build-${{ github.sha }}
         restore-keys: |
           maven-windup-rulesets-build-${{ github.sha }}
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.8.7
     - name: Maven build
       run: mvn clean install -DskipTests -B -s build/settings.xml

--- a/.github/workflows/pull_request_push_build.yml
+++ b/.github/workflows/pull_request_push_build.yml
@@ -79,6 +79,8 @@ jobs:
       with:
         path: ~/.m2/repository
         key: maven-windup-cli-build-${{ github.sha }}
+        enableCrossOsArchive: true
+        fail-on-cache-miss: true
         restore-keys: |
           maven-windup-rulesets-build-${{ github.sha }}
     - name: Set up Maven

--- a/pom.xml
+++ b/pom.xml
@@ -87,13 +87,6 @@
                     <groupId>org.jboss.forge.furnace</groupId>
                     <artifactId>furnace-maven-plugin</artifactId>
                     <version>${version.furnace}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-utils</artifactId>
-                            <version>3.5.0</version>
-                        </dependency>
-                    </dependencies>
                     <executions>
                         <execution>
                             <id>deploy-addons</id>
@@ -223,7 +216,7 @@
                 <groupId>org.jboss.forge.furnace</groupId>
                 <artifactId>furnace-maven-plugin</artifactId>
                 <!-- Configuration won't be propagated to children -->
-                <inherited>true</inherited>
+                <inherited>false</inherited>
                 <executions>
                     <execution>
                         <!--This matches and thus overrides execution defined above -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3690

This PR:

- reverts changes in https://github.com/windup/windup-distribution/pull/104
- closes https://github.com/windup/windup-distribution/pull/109
- fix the Maven version to `3.8.7` to be safe in building as long as a reliable solution is developed
- enhanced the cache management letting the Windows runner to restore a previous "Linux" cache